### PR TITLE
Fix "dependencies" containing "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,17 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "decimal.js": "^6.0.0",
-    "gulp-spawn-mocha": "^3.1.0",
-    "gulp-watch": "^4.3.10",
-    "karma": "^1.3.0",
     "long": "^3.2.0",
-    "mocha": "^3.1.0",
-    "nodemon": "^1.10.2",
-    "nyc": "^8.3.0",
-    "shx": "^0.1.4",
-    "sinon": "^1.17.6",
-    "ts-node": "^1.3.0",
-    "typescript": "^2.0.3"
   },
   "devDependencies": {
     "@types/chai": "^3.4.32",
@@ -53,16 +43,16 @@
     "@types/sinon": "^1.16.29",
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
-    "gulp-spawn-mocha": "^3.0.0",
-    "gulp-watch": "^4.3.9",
-    "karma": "^1.1.2",
-    "mocha": "^3.0.1",
-    "nodemon": "^1.10.0",
-    "nyc": "^7.1.0",
-    "shx": "^0.1.2",
-    "sinon": "^1.17.5",
-    "ts-node": "^1.2.2",
-    "typescript": "^2.0.0"
+    "gulp-spawn-mocha": "^3.1.0",
+    "gulp-watch": "^4.3.10",
+    "karma": "^1.3.0",
+    "mocha": "^3.1.0",
+    "nodemon": "^1.10.2",
+    "nyc": "^8.3.0",
+    "shx": "^0.1.4",
+    "sinon": "^1.17.6",
+    "ts-node": "^1.3.0",
+    "typescript": "^2.0.3"
   },
   "nyc": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodes2ts",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "a Typescript porting of the great S2 Geometry library from Google ",
   "main": "dist/export.js",
   "homepage": "https://github.com/vekexasia/nodes2-ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "decimal.js": "^6.0.0",
-    "long": "^3.2.0",
+    "long": "^3.2.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.32",


### PR DESCRIPTION
This issue is causing our build package to balloon massively since the nodes2ts package is bringing in the entire typescript package, as well as a number of other dev dependencies.